### PR TITLE
Fix target attribute in social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 <h3 align="left">Connect with me:</h3>
 <p align="left">
-<a href="https://twitter.com/ghostwo51501818" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="ghostwo51501818" height="30" width="40" /></a>
-<a href="https://instagram.com/ghostwolfgg199" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/instagram.svg" alt="ghostwolfgg199" height="30" width="40" /></a>
-<a href="https://www.youtube.com/channel/UCUdGYA2WbQrzIG0W8rtnOpg" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/youtube.svg" alt="ucudgya2wbqrzig0w8rtnopg" height="30" width="40" /></a>
-<a href="https://discord.gg/zbQpdRgQgT" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/discord.svg" alt="zbQpdRgQgT" height="30" width="40" /></a>
+<a href="https://twitter.com/ghostwo51501818" target="_blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="ghostwo51501818" height="30" width="40" /></a>
+<a href="https://instagram.com/ghostwolfgg199" target="_blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/instagram.svg" alt="ghostwolfgg199" height="30" width="40" /></a>
+<a href="https://www.youtube.com/channel/UCUdGYA2WbQrzIG0W8rtnOpg" target="_blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/youtube.svg" alt="ucudgya2wbqrzig0w8rtnopg" height="30" width="40" /></a>
+<a href="https://discord.gg/zbQpdRgQgT" target="_blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/discord.svg" alt="zbQpdRgQgT" height="30" width="40" /></a>
 </p>
 
 <h3 align="left">Languages and Tools:</h3>


### PR DESCRIPTION
## Summary
- fix HTML `target` attribute for social links in README

## Testing
- `grep -n "target=\"_blank\"" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_684c66ee4c94832990bc2b209dec7ded